### PR TITLE
Fix Null in Chat Window

### DIFF
--- a/Minebot/src/net/famzangl/minecraft/minebot/ai/command/AIChatController.java
+++ b/Minebot/src/net/famzangl/minecraft/minebot/ai/command/AIChatController.java
@@ -164,10 +164,13 @@ public class AIChatController {
 
 	public static <T> void addToChatPaged(String title, int page, List<T> data,
 			Function<T, String> convert) {
-		AIChatController.addChatLine(title + " " + page + " / "
-				+ (int) Math.ceil((float) data.size() / PER_PAGE));
-		for (int i = Math.max(0, page - 1) * PER_PAGE; i < Math.min(page
-				* PER_PAGE, data.size()); i++) {
+
+		int totalPages = (int) Math.ceil(data.size() / PER_PAGE);
+		AIChatController.addChatLine(title + " " + page + " / " + totalPages);
+
+		int start = Math.max(0, page - 1) * PER_PAGE;
+		int end = Math.min(page * PER_PAGE, data.size());
+		for (int i = start; i < end; i++) {
 			final String line = convert.apply(data.get(i));
 			addChatLine(line);
 		}

--- a/Minebot/src/net/famzangl/minecraft/minebot/ai/commands/CommandHelp.java
+++ b/Minebot/src/net/famzangl/minecraft/minebot/ai/commands/CommandHelp.java
@@ -31,6 +31,7 @@ import net.famzangl.minecraft.minebot.ai.command.CommandDefinition;
 import net.famzangl.minecraft.minebot.ai.command.FixedNameBuilder.FixedArgumentDefinition;
 import net.famzangl.minecraft.minebot.ai.command.ParameterType;
 import net.famzangl.minecraft.minebot.ai.strategy.AIStrategy;
+import net.famzangl.minecraft.minebot.ai.strategy.StopStrategy;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.util.ChatComponentText;
 
@@ -96,7 +97,7 @@ final public class CommandHelp {
 		Collections.sort(commands, new CommandComperator());
 		AIChatController.addToChatPaged("Help", page, commands,
 				new CommandToTextConverter());
-		return null;
+		return new StopStrategy();
 
 	}
 
@@ -122,7 +123,7 @@ final public class CommandHelp {
 			AIChatController.addChatLine("Command could not be found: "
 					+ commandName);
 		}
-		return null;
+		return new StopStrategy();
 	}
 
 	private static void printHelp(EntityPlayerSP player,


### PR DESCRIPTION
Doing `/minebot help` ouputs a null error.
Actually nothing is wrong, just no Strategy is returned.
Return a StopStrategy instead of null.